### PR TITLE
Fix specifying loadSchema() function from webpack configuration

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,9 +22,8 @@ module.exports = function (schemaStr, sourceMap) {
     const defaultAjvOptions = { loadSchema };
     // Maybe will be used in future
     const options           = loaderUtils.getOptions(this) || {};
-    const ajvOptions        = options.ajv || {};
     // { sourceCode: true } should not be overridden
-    Object.assign(ajvOptions, defaultAjvOptions, ajvOptions, { sourceCode: true });
+    const ajvOptions        = Object.assign({}, defaultAjvOptions, options.ajv || {}, { sourceCode: true });
 
     const ajv = new Ajv(ajvOptions);
 


### PR DESCRIPTION
Object.assign() assigns the properties to its first parameter, which results in ajvOptions immediately being overwritten with the defaults that are provided. The second time ajvOptions is passed, it has no effect, because configuration options have already been overwritten by their defaults.